### PR TITLE
Make `ValuePath` properties public

### DIFF
--- a/src/Ast/ValuePath.php
+++ b/src/Ast/ValuePath.php
@@ -14,10 +14,10 @@ namespace Tmilos\ScimFilterParser\Ast;
 class ValuePath extends Factor
 {
     /** @var AttributePath */
-    private $attributePath;
+    public $attributePath;
 
     /** @var Filter */
-    private $filter;
+    public $filter;
 
     /**
      * @param AttributePath $attributePath


### PR DESCRIPTION
Similar to `ComparisonExpression`, I've updated the property visibility of `ValuePath` to `public` so that they may be accessed when parsing filter nodes:

https://github.com/tmilos/scim-filter-parser/blob/c022625976826d392f7924c952bb491608230ec7/src/Ast/ComparisonExpression.php#L14-L23

Let me know if you'd like anything changed or adjusted, thanks! 🙏 